### PR TITLE
Temporary fix for tracktion crash -- setting default buffer size (system defaults to 1024)

### DIFF
--- a/modules/juce_audio_devices/native/juce_ios_Audio.cpp
+++ b/modules/juce_audio_devices/native/juce_ios_Audio.cpp
@@ -1342,7 +1342,7 @@ struct iOSAudioIODevice::Pimpl      : public AudioPlayHead,
    #if TARGET_IPHONE_SIMULATOR
     static constexpr int defaultBufferSize = 512;
    #else
-    static constexpr int defaultBufferSize = 256;
+    static constexpr int defaultBufferSize = 1024;
    #endif
     int targetBufferSize = defaultBufferSize, bufferSize = targetBufferSize;
 

--- a/modules/juce_audio_devices/native/juce_ios_Audio.cpp
+++ b/modules/juce_audio_devices/native/juce_ios_Audio.cpp
@@ -1342,6 +1342,7 @@ struct iOSAudioIODevice::Pimpl      : public AudioPlayHead,
    #if TARGET_IPHONE_SIMULATOR
     static constexpr int defaultBufferSize = 512;
    #else
+   // Updating to 1024 as a temporary fix until we can find better ways of catching CHOC_ASSERT 
     static constexpr int defaultBufferSize = 1024;
    #endif
     int targetBufferSize = defaultBufferSize, bufferSize = targetBufferSize;


### PR DESCRIPTION
Seems a default buffer size is 1024 helps with iOS devices