### PR TITLE
Revert the preprocessing mode change for now.

### DIFF
--- a/modules/juce_audio_devices/native/juce_ios_Audio.cpp
+++ b/modules/juce_audio_devices/native/juce_ios_Audio.cpp
@@ -966,8 +966,6 @@ struct iOSAudioIODevice::Pimpl      : public AudioPlayHead,
         desc.componentFlags = 0;
         desc.componentFlagsMask = 0;
                 
-        setAudioPreprocessingEnabled(isUsingBuiltInSpeaker());
-        
         AudioComponent comp = AudioComponentFindNext (nullptr, &desc);
         AudioComponentInstanceNew (comp, &audioUnit);
 


### PR DESCRIPTION
It seems to be causing volume issues without headphones and breaks ability to play back through headphones. I suspect we can use this for wired headphones only, but for now, just doing a clean revert so that we can test the build fresh.

Thank you for submitting a pull request.

Please make sure you have read and followed our contribution guidelines (.github/contributing.md in this repository). Your pull request will not be accepted if you have not followed the instructions.

