### PR TITLE
Remove an assertion breaking the android app build.

### DIFF
--- a/modules/juce_audio_devices/native/juce_android_Oboe.cpp
+++ b/modules/juce_audio_devices/native/juce_android_Oboe.cpp
@@ -1256,7 +1256,7 @@ public:
             case 23:  return "hearing aid";
             case 24:  return "built-in speaker safe";
             case 25:  return {};
-            default:  jassertfalse; return {}; // type not supported yet, needs to be added!
+            default:  return {}; // type not supported yet, needs to be added!
         }
     }
 


### PR DESCRIPTION
Remove an assertion about unsupported audio device types because it doesn't actually matter if a new type isn't yet supported by tracktion. We only care about bluetooth, speaker, wired headphones, etc. for now anyway.

Thank you for submitting a pull request.

Please make sure you have read and followed our contribution guidelines (.github/contributing.md in this repository). Your pull request will not be accepted if you have not followed the instructions.

