### PR TITLE
Fix/audio preprocessing test

### DIFF
--- a/modules/juce_audio_devices/native/juce_ios_Audio.cpp
+++ b/modules/juce_audio_devices/native/juce_ios_Audio.cpp
@@ -1016,7 +1016,7 @@ struct iOSAudioIODevice::Pimpl      : public AudioPlayHead,
         setAnalogInputGain(0.5f);
         
         if (isUsingBuiltInSpeaker() && !AudioIODeviceType::useDeviceVoiceProcessing) {
-            setAudioPreprocessingEnabled(true);
+            setAudioPreprocessingEnabled(false);
             selectMicPosition(MicPosition::Front);
         }
 

--- a/modules/juce_audio_devices/native/juce_ios_Audio.cpp
+++ b/modules/juce_audio_devices/native/juce_ios_Audio.cpp
@@ -1016,6 +1016,7 @@ struct iOSAudioIODevice::Pimpl      : public AudioPlayHead,
         setAnalogInputGain(0.5f);
         
         if (isUsingBuiltInSpeaker() && !AudioIODeviceType::useDeviceVoiceProcessing) {
+            setAnalogInputGain(1.f);
             setAudioPreprocessingEnabled(false);
             selectMicPosition(MicPosition::Front);
         }


### PR DESCRIPTION
By using `AVAudioSessionModeMeasurement` we can mute the loudspeaker next to the top front mic in newer iPhones